### PR TITLE
simplify layout selection

### DIFF
--- a/client.d.ts
+++ b/client.d.ts
@@ -1,6 +1,4 @@
 declare module 'layouts-generated' {
   import { RouteRecordRaw } from 'vue-router'
   export function setupLayouts(routes: RouteRecordRaw[])
-  export function createRouterLayout(
-    resolve: (layoutName: string) => Promise<Component | { default: Component }>)
 }

--- a/src/RouteLayout.ts
+++ b/src/RouteLayout.ts
@@ -2,64 +2,14 @@
 
 function getClientCode(importCode: string) {
   const code = `
-import {
-  h,
-  ref,
-  computed,
-  defineComponent,
-  shallowReactive,
-  resolveComponent
-} from 'vue'
-import { useRouter, useRoute } from 'vue-router'
-
 ${importCode}
 
 export function setupLayouts(routes) {
-  return [
-    {
-      path: '/',
-      component: createRouterLayout(layouts),
-      children: routes,
-    },
-  ]
-}
-
-async function resolveLayout(layout) {
-  if (typeof layout === 'function') {
-    return (await layout())?.default
-  }
-  return layout
-} 
-
-export function createRouterLayout(_layouts) {
-  return defineComponent(() => {
-    const router = useRouter()
-    const route = useRoute()
-
-    const name = ref('default')
-    const layouts = shallowReactive(_layouts)
-    const layout = computed(() => layouts[name.value])
-  
-    async function updateLayout(_name) {
-      if (typeof layouts[_name] === 'function')
-        layouts[_name] = await resolveLayout(layouts[_name])
-      name.value = _name || 'default'
-    }
-
-    router.beforeEach(async (to, from, next) => {
-      await updateLayout(to.meta?.layout)
-      next()
-    })
-
-    updateLayout(route.meta?.layout)
-
-    return () => {
-      if (!layout.value || typeof layout.value === 'function')
-        return h(resolveComponent('router-view'))
-
-      return h(layout.value, {
-        key: layout.name,
-      })
+  return routes.map((route) => {
+    return { 
+      path: route.path,
+      component: layouts[route.meta?.layout || 'default'],
+      children: [route],
     }
   })
 }


### PR DESCRIPTION
change nested routes object to a flat routes object

P.S.: Sorry, messed up with the branches and have to recommit this PR

fixes #4,
fixes #6,
fixes #11,
fixes #14

If you want to test with your own project use the fork at [@ctholho/vite-plugin-vue-layouts#next-build](https://github.com/ctholho/vite-plugin-vue-layouts/tree/next-build) which builds the package automatically. Alternatively, run `npm update && npm run build` in the modules directory.

## How to test with your own project
```
pnpm remove vite-plugin-vue-layouts
pnpm add ctholho/vite-plugin-vue-layouts#next-build -D
```

Then simply do your thing:
`pnpm dev` or `pnpm build`.

## To reset:
```
pnpm remove vite-plugin-vue-layouts
pnpm add vite-plugin-vue-layouts -D
```