### PR TITLE
Update vite plugin pages import

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ In main.ts, you need to add a few lines to import the generated code and setup t
 ```js
 import { createRouter } from 'vue-router'
 import { setupLayouts } from 'layouts-generated'
-import generatedRoutes from 'pages-generated'
+import generatedRoutes from 'virtual:generated-pages'
 
 const routes = setupLayouts(generatedRoutes)
 

--- a/examples/spa/src/main.ts
+++ b/examples/spa/src/main.ts
@@ -1,7 +1,7 @@
 import { createApp } from 'vue'
 import { createRouter, createWebHistory } from 'vue-router'
 import { setupLayouts } from 'layouts-generated'
-import generatedRoutes from 'pages-generated'
+import generatedRoutes from 'virtual:generated-pages'
 import App from './App.vue'
 import './index.css'
 

--- a/examples/ssg/src/main.ts
+++ b/examples/ssg/src/main.ts
@@ -1,5 +1,5 @@
 import { setupLayouts } from 'layouts-generated'
-import generatedRoutes from 'pages-generated'
+import generatedRoutes from 'virtual:generated-pages'
 import { ViteSSG } from 'vite-ssg'
 import App from './App.vue'
 import './index.css'


### PR DESCRIPTION
vite-plugin-pages refers in its docs to import via `import generatedRoutes from 'virtual:generated-pages'` since hannoeru/vite-plugin-pages@d297e80 (v0.7.0)

fixes #9