### PR TITLE
Fix ESM imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,13 @@
     "dist",
     "client.d.ts"
   ],
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./*": "./*"
+  },
   "scripts": {
     "dev": "npm run build -- --watch",
     "build": "tsup src/index.ts --dts --format cjs,esm",


### PR DESCRIPTION
Add `exports` mapping to `package.json`
The inclusion of `"./*": "./*"` should make it non-breaking and continue to allow direct importing of files inside the package.

closes #50 