### PR TITLE
Preserve route metadata

### DIFF
--- a/src/RouteLayout.ts
+++ b/src/RouteLayout.ts
@@ -8,6 +8,7 @@ export function setupLayouts(routes) {
   return routes.map(route => {
     return { 
       path: route.path,
+      meta: route.meta,
       component: layouts[route.meta?.layout || '${options.defaultLayout}'],
       children: [ {...route, path: ''} ],
     }


### PR DESCRIPTION
Currently the route metadata is only present on the child route generated by this plugin but is absent from the parent.
This is an issue when it needs to be access from the route guards as the parent route is the one that gets matched therefore the metadata is inaccessible. ([originally mentioned here](https://github.com/JohnCampionJr/vite-plugin-vue-layouts/issues/47#issuecomment-968550025))

This PR copies the metadata of the child route to the parent route.