### PR TITLE
fix: extra .html generated when vite-ssg dirStyles flat

### DIFF
--- a/src/RouteLayout.ts
+++ b/src/RouteLayout.ts
@@ -6,12 +6,11 @@ ${importCode}
 
 export function setupLayouts(routes) {
   return routes.map(route => {
-    const destRoute = { 
+    return { 
       path: route.path,
       component: layouts[route.meta?.layout || '${options.defaultLayout}'],
+      children: route.path === '/' ? [route] : [{...route, path: ''}]}
     }
-    if (route.path !== '/') destRoute.children = [ {...route, path: ''} ]
-    return destRoute
   })
 }
 `

--- a/src/RouteLayout.ts
+++ b/src/RouteLayout.ts
@@ -9,7 +9,7 @@ export function setupLayouts(routes) {
     return { 
       path: route.path,
       component: layouts[route.meta?.layout || '${options.defaultLayout}'],
-      children: route.path === '/' ? [route] : [{...route, path: ''}]}
+      children: route.path === '/' ? [route] : [{...route, path: ''}]
     }
   })
 }

--- a/src/RouteLayout.ts
+++ b/src/RouteLayout.ts
@@ -6,11 +6,12 @@ ${importCode}
 
 export function setupLayouts(routes) {
   return routes.map(route => {
-    return { 
+    const destRoute = { 
       path: route.path,
       component: layouts[route.meta?.layout || '${options.defaultLayout}'],
-      children: [ {...route, path: ''} ],
     }
+    if (route.path !== '/') destRoute.children = [ {...route, path: ''} ]
+    return destRoute
   })
 }
 `


### PR DESCRIPTION
I found @ctholho create a PR https://github.com/JohnCampionJr/vite-plugin-vue-layouts/pull/27 to fix vite-ssg dirStyles `nested`.

But it will generate an extra file `.html` when dirStyles`flat`.

This file has no effect in most cases, but when using `github pages`(vercel/netlify/cloudflare works well), it is parsed as binary and cannot be routed to `index.html`.