### PR TITLE
Fix HMR reloading problem when a files is added or deleted everywhere in the projet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ If you want type definition of `virtual:generated-layouts`, add `vite-plugin-vue
 ```ts
 interface UserOptions {
   layoutsDirs?: string | string[]
+  pagesDir?: string
   exclude: string[]
   defaultLayout?: string
 }
@@ -91,6 +92,7 @@ export default {
   plugins: [
     Layouts({
       layoutsDirs: 'src/mylayouts',
+      pagesDir: 'src/pages',
       defaultLayout: 'myDefault'
     }),
   ],
@@ -107,6 +109,14 @@ Can also be an array of layout dirs
 Any files named `__*__.vue` will be excluded, and you can specify any additional exclusions with the `exclude` option
 
 **Default:** `'src/layouts'`
+
+### pagesDir
+
+Set this to avoid HMR reloading for all added or deleted files anywhere in the projet.
+
+Relative path to the pages directory.
+
+**Default:** `null`
 
 ## How it works
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ function resolveOptions(userOptions: UserOptions): ResolvedOptions {
     {
       defaultLayout: 'default',
       layoutsDirs: 'src/layouts',
+      pagesDir: null,
       extensions: ['vue'],
       exclude: [],
       importMode: defaultImportMode,
@@ -54,18 +55,25 @@ function layoutPlugin(userOptions: UserOptions = {}): Plugin {
         }
       }
 
-      const updateVirtualModule = () => {
-        const module = moduleGraph.getModuleById(MODULE_ID_VIRTUAL)
+      const absolutePagesDir = options.pagesDir ? normalizePath(resolve(process.cwd(), options.pagesDir)) : null
 
+      const updateVirtualModule = (path: string) => {
+        path = `${normalizePath(path)}`
+
+        // If absolutePagesDir is defined and path doesn't correspond to pagesDir
+        if (absolutePagesDir && !~path.indexOf(absolutePagesDir))
+          return
+
+        const module = moduleGraph.getModuleById(MODULE_ID_VIRTUAL)
         reloadModule(module)
       }
 
-      watcher.on('add', () => {
-        updateVirtualModule()
+      watcher.on('add', (path) => {
+        updateVirtualModule(path)
       })
 
-      watcher.on('unlink', () => {
-        updateVirtualModule()
+      watcher.on('unlink', (path) => {
+        updateVirtualModule(path)
       })
 
       watcher.on('change', async(path) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,11 @@ interface Options {
    */
   layoutsDirs: string | string[]
   /**
+   * Relative path to the pages directory.
+   * @default null
+   */
+  pagesDir?: string
+  /**
    * Valid file extensions for page components.
    * @default ['vue']
    */


### PR DESCRIPTION
Added an option pagesDir to resolve this problem.

Without this, the page reload entire instead of just a module.

PhpStorm create lot of temp, or laravel push some logs too.

Fix this https://github.com/JohnCampionJr/vite-plugin-vue-layouts/issues/94