### PR TITLE
perf!: use clientLayout as needed in defaultLayout

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,7 @@ export type FileContainer = {
 }
 export type UserOptions = Partial<Options>
 
-export interface ResolvedOptions extends Options {}
+export interface ResolvedOptions extends Options { }
 
 export interface clientSideOptions {
   /**
@@ -54,5 +54,5 @@ export interface clientSideOptions {
   /**
    * default auto resolve
    */
-  importMode: 'sync' | 'async'
+  importMode?: 'sync' | 'async'
 }


### PR DESCRIPTION
Now we can determine whether or not to apply the clientLayout by the type of option, without changing any user behavior, with all the performance gains we can get in development。

(Similar techniques are also used in [vite-plugin-removelog](https://github.com/dishait/vite-plugin-removelog/blob/main/src/index.ts#L32), balancing customization and performance)

Before we merge this pr, I think we have to deal with the issue as well → #130 

The best practice is to make clientLayout and defaultLayout consistent