### PR TITLE
fix(examples/ssg): change the type to module to support normal vite b…

### DIFF
--- a/examples/ssg/package.json
+++ b/examples/ssg/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "nodemon --watch ../../dist/index.js -x \"cross-env DEBUG=vite-plugin-layouts vite\"",
     "build": "cross-env DEBUG=vite-plugin-layouts vite-ssg build",


### PR DESCRIPTION
I tested all the example builds and found that ssg needs to add the type module in order to be packaged correctly.
